### PR TITLE
docs: pin usage examples to @v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action allows you to combine a bunch of individual status checks into one r
 Filter checks by regex pattern - useful for dynamically named checks:
 
 ```yaml
-- uses: etsy/combined-status-check@v1
+- uses: etsy/combined-status-check@v2
   with:
     status-regex: "^Some Third Party"
 ```
@@ -19,7 +19,7 @@ Filter checks by regex pattern - useful for dynamically named checks:
 Specify exact check run names that must all appear and succeed:
 
 ```yaml
-- uses: etsy/combined-status-check@v1
+- uses: etsy/combined-status-check@v2
   with:
     required-check-runs: |
       build
@@ -39,7 +39,7 @@ This mode:
 Skip all status checks for branches with a specific prefix:
 
 ```yaml
-- uses: etsy/combined-status-check@v1
+- uses: etsy/combined-status-check@v2
   with:
     auto-pass-branch-prefix: "grimoire-"
     required-check-runs: |


### PR DESCRIPTION
## Summary

The `v2.0.0` release ships the node24 runtime upgrade. This updates the README usage examples to pin the new major version.

## Changes

- README usage examples: `etsy/combined-status-check@v1` → `@v2` (3 occurrences)

## Note

This depends on a floating `v2` major tag existing on the repo so `@v2` resolves. If it hasn't been pushed yet:

```bash
git tag -f v2 <v2.0.0 commit sha>
git push -f origin refs/tags/v2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012F4rPsxKMt8n1Jn2ZjSfHk)_